### PR TITLE
Removed second delay on eeprom writes

### DIFF
--- a/src/mlx90614.rs
+++ b/src/mlx90614.rs
@@ -94,6 +94,25 @@ where
         }
         self.write_u16_eeprom(Register::EMISSIVITY, eps as u16, delay)
     }
+
+    /// Set the entire contents of the PWMCTRL EEPROM register.
+    /// See datasheet, section 8.3.3.
+    pub fn set_pwmctrl<D: DelayMs<u8>>(
+        &mut self,
+        word: u16,
+        delay: &mut D,
+    ) -> Result<(), Error<E>> {
+        // todo: This would make more sense with individual settings, instead
+        // todo of writing the whole register with a word.
+        self.write_u16_eeprom(Register::PWMCTRL, word, delay)
+    }
+
+    /// Read the entire contents of the PWMCTRL EEPROM register.
+    pub fn pwmctrl(&mut self) -> Result<u16, Error<E>> {
+        // todo: See note about individual settings in `set_pwmctrl`.
+        self.read_u16(Register::PWMCTRL)
+    }
+
     /// Enter sleep mode. See datasheet, section 8.4.5.
     pub fn sleep(&mut self) -> Result<(), Error<E>> {
         // self.write_u16(0b1111_1111, 0)? // todo test this.

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -3,7 +3,9 @@ use embedded_hal::blocking::{delay, i2c};
 use smbus_pec::pec;
 
 pub mod mlx90614 {
+    // For these addresses, reference datasheet, section 8.4.5.
     const EEPROM_COMMAND: u8 = 0x20;
+    const SLEEP_COMMAND: u8 = 0b1111_1111;
     pub const DEV_ADDR: u8 = 0x5A;
     pub struct Register {}
     impl Register {
@@ -74,7 +76,6 @@ where
         self.write_u16(command, 0)?;
         delay.delay_ms(self.eeprom_write_delay_ms);
         self.write_u16(command, data)?;
-
         Ok(())
     }
 

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -74,7 +74,7 @@ where
         self.write_u16(command, 0)?;
         delay.delay_ms(self.eeprom_write_delay_ms);
         self.write_u16(command, data)?;
-        delay.delay_ms(self.eeprom_write_delay_ms);
+
         Ok(())
     }
 

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -9,6 +9,7 @@ pub mod mlx90614 {
     pub const DEV_ADDR: u8 = 0x5A;
     pub struct Register {}
     impl Register {
+        pub const PWMCTRL: u8 = 0x02 | EEPROM_COMMAND;
         pub const RAW_IR1: u8 = 0x04;
         pub const RAW_IR2: u8 = 0x05;
         pub const TA: u8 = 0x06;


### PR DESCRIPTION
This PR removes the second delay during EEPROM writes. This delay is due to the note in the datasheet that a delay of 5ms (conservatively 10ms) between eeprom writes is required to prevent bugs. I've confirmed this: Wacky stuff happens if you don't delay! 

This PR is due to the delay being inconsistent: We need the one between the writes. Currently, the onus is on the user to execute delays otherwise, ie between reads, or between read and write commands. I see two options:

#1: This PR as-is, ie removing all internal delays except the one between two writes. The user must insert delays etc in their code.
#2: Add a delay after or before each read. This would avoid the user having to add delays, but adds latency in situations where it may not be needed