### PR TITLE
 feat: methods for reading temp as a u16 value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] - 2023-05-26
+
+### Added
+- Methods for reading tempature as a integer (`u16`).
+  Users are advised to ONLY use these methods if running into to trouble using 
+  the standard tempature reading methods returning `f32` values as it's a more accurate read.
+
 
 ## [0.2.0] - 2021-05-22
 

--- a/src/mlx90614.rs
+++ b/src/mlx90614.rs
@@ -45,10 +45,24 @@ where
         Ok(t)
     }
 
+    /// Read the ambient temperature in celsius degrees as u16 value
+    pub fn ambient_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
+        let t = self.read_u16(Register::TA)?;
+        let t = (t * 2) / 100 - 273;
+        Ok(t)
+    }
+
     /// Read the object 1 temperature in celsius degrees
     pub fn object1_temperature(&mut self) -> Result<f32, Error<E>> {
         let t = self.read_u16(Register::TOBJ1)?;
         let t = f32::from(t) * 0.02 - 273.15;
+        Ok(t)
+    }
+
+    /// Read the object 1 temperature in celsius degrees as u16 value
+    pub fn object1_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
+        let t = self.read_u16(Register::TOBJ1)?;
+        let t = (t * 2) / 100 - 273;
         Ok(t)
     }
 
@@ -58,6 +72,15 @@ where
     pub fn object2_temperature(&mut self) -> Result<f32, Error<E>> {
         let t = self.read_u16(Register::TOBJ2)?;
         let t = f32::from(t) * 0.02 - 273.15;
+        Ok(t)
+    }
+
+    /// Read the object 2 temperature in celsius degrees as u16 value
+    ///
+    /// Note that this is only available in dual-zone thermopile device variants.
+    pub fn object2_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
+        let t = self.read_u16(Register::TOBJ2)?;
+        let t = (t * 2) / 100 - 273;
         Ok(t)
     }
 

--- a/src/mlx90614.rs
+++ b/src/mlx90614.rs
@@ -46,6 +46,9 @@ where
     }
 
     /// Read the ambient temperature in celsius degrees as u16 value
+    ///
+    /// Note ONLY use to avoid floating-point ops, as this gives less accurate
+    /// temperature readings compared to using `ambient_temperature()`.
     pub fn ambient_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
         let t = self.read_u16(Register::TA)?;
         let t = (t * 2) / 100 - 273;
@@ -60,6 +63,9 @@ where
     }
 
     /// Read the object 1 temperature in celsius degrees as u16 value
+    ///
+    /// Note ONLY use to avoid floating-point ops, as this gives less accurate
+    /// temperature readings compared to using `object1_temperature()`.
     pub fn object1_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
         let t = self.read_u16(Register::TOBJ1)?;
         let t = (t * 2) / 100 - 273;
@@ -78,6 +84,9 @@ where
     /// Read the object 2 temperature in celsius degrees as u16 value
     ///
     /// Note that this is only available in dual-zone thermopile device variants.
+    ///
+    /// Note ONLY use to avoid floating-point ops, as this gives less accurate
+    /// temperature readings compared to using `object2_temperature()`.
     pub fn object2_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
         let t = self.read_u16(Register::TOBJ2)?;
         let t = (t * 2) / 100 - 273;

--- a/src/mlx90615.rs
+++ b/src/mlx90615.rs
@@ -49,6 +49,9 @@ where
     }
 
     /// Read the ambient temperature in celsius degrees as u16 value
+    ///
+    /// Note ONLY use to avoid floating-point ops, as this gives less accurate
+    /// temperature readings compared to using `ambient_temperature()`.
     pub fn ambient_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
         let t = self.read_u16(Register::TA)?;
         let t = (t * 2) / 100 - 273;
@@ -63,6 +66,9 @@ where
     }
 
     /// Read the object temperature in celsius degrees
+    ///
+    /// Note ONLY use to avoid floating-point ops, as this gives less accurate
+    /// temperature readings compared to using `object_temperature()`.
     pub fn object_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
         let t = self.read_u16(Register::TOBJ)?;
         let t = (t * 2) / 100 - 273;

--- a/src/mlx90615.rs
+++ b/src/mlx90615.rs
@@ -48,10 +48,24 @@ where
         Ok(t)
     }
 
+    /// Read the ambient temperature in celsius degrees as u16 value
+    pub fn ambient_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
+        let t = self.read_u16(Register::TA)?;
+        let t = (t * 2) / 100 - 273;
+        Ok(t)
+    }
+
     /// Read the object temperature in celsius degrees
     pub fn object_temperature(&mut self) -> Result<f32, Error<E>> {
         let t = self.read_u16(Register::TOBJ)?;
         let t = f32::from(t) * 0.02 - 273.15;
+        Ok(t)
+    }
+
+    /// Read the object temperature in celsius degrees
+    pub fn object_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
+        let t = self.read_u16(Register::TOBJ)?;
+        let t = (t * 2) / 100 - 273;
         Ok(t)
     }
 

--- a/tests/mlx90614.rs
+++ b/tests/mlx90614.rs
@@ -48,6 +48,42 @@ read_f32_test!(
 );
 
 read_u16_test!(
+    read_ta_as_int,
+    new_mlx90614,
+    mlx90614::DEV_ADDR,
+    ambient_temperature_as_int,
+    Reg::TA,
+    0x0,
+    0x3A,
+    0xB6,
+    0x17
+);
+
+read_u16_test!(
+    read_object1_temp_as_int,
+    new_mlx90614,
+    mlx90614::DEV_ADDR,
+    object1_temperature_as_int,
+    Reg::TOBJ1,
+    0x26,
+    0x3A,
+    0x70,
+    0x18
+);
+
+read_u16_test!(
+    read_object2_temp_as_int,
+    new_mlx90614,
+    mlx90614::DEV_ADDR,
+    object2_temperature_as_int,
+    Reg::TOBJ2,
+    0x26,
+    0x3A,
+    0xA2,
+    0x18
+);
+
+read_u16_test!(
     read_raw_ir1,
     new_mlx90614,
     mlx90614::DEV_ADDR,

--- a/tests/mlx90615.rs
+++ b/tests/mlx90615.rs
@@ -38,6 +38,30 @@ read_f32_test!(
 );
 
 read_u16_test!(
+    read_object_temp_as_int,
+    new_mlx90615,
+    mlx90615::DEV_ADDR,
+    object_temperature_as_int,
+    Reg::TOBJ,
+    0x26,
+    0x3A,
+    0xAC,
+    0x18
+);
+
+read_u16_test!(
+    read_ta_as_int,
+    new_mlx90615,
+    mlx90615::DEV_ADDR,
+    ambient_temperature_as_int,
+    Reg::TA,
+    0x26,
+    0x3A,
+    0xBA,
+    0x18
+);
+
+read_u16_test!(
     read_raw_ir,
     new_mlx90615,
     mlx90615::DEV_ADDR,


### PR DESCRIPTION
This library has an emphasis on platform agnostic, but I ran into a LOT of problems trying to work with the `f32` values returned from the methods in this library when running on bare metal. 

I know using `u16` is a little less accurate than `f32`, but it's nice to be able to call a method that just works out of the box when running on bare metal. 

This PR introduces 3 new methods for `Mlx90614` and 2 new methods for `Mlx90615` which are all just clones of existing temperature methods but persevering their raw u16 value type.

I'm not 100% sold on the method names, and definitely open to suggestions.

Also willing to write additional docs, tests, and examples for these :) , if you think this feature will be merged. 

Fixes #3 