### PR TITLE
Update to embedded_hal 1.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "rust-analyzer.check.command": "clippy",
+    "rust-analyzer.check.allTargets": false,
+    "rust-analyzer.check.extraArgs": [
+        "--target",
+        "x86_64-unknown-linux-musl"
+    ],
+    "rust-analyzer.cargo.noDefaultFeatures": true,
+    "rust-analyzer.imports.preferNoStd": true,
+    "rust-analyzer.showUnlinkedFileNotification": false,
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "rust-analyzer.check.command": "clippy",
-    "rust-analyzer.check.allTargets": false,
+    "rust-analyzer.check.allTargets": true,
     "rust-analyzer.check.extraArgs": [
         "--target",
         "x86_64-unknown-linux-musl"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - [breaking-change] Transitioned `embedded-hal` to version 1.0
-- Add feature defmt-03
-- When feature enabled, "defmt::Format" is derived for any public struct or enum that derives Debug.
+- Add feature `defmt-03` to derive "`defmt::Format`" from `defmt = "0.3"` for public types.
 
 ## [0.2.1] - 2023-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-05-21
+
+### Changed
+
+- [breaking-change] Transitioned `embedded-hal` to version 1.0
+
 ## [0.2.1] - 2023-06-02
 
 ### Added
+
 - Methods for reading tempature as a integer (`u16`).
   Users are advised to ONLY use these methods if running into to trouble using
-  the standard tempature reading methods returning `f32` values as it's a more accurate read.
+  the standard temperature reading methods returning `f32` values as it's a more accurate read.
 
 ## [0.2.0] - 2021-05-22
 
 ### Added
+
 - Add support for device sleep and wake.
 
 ### Changed
+
 - Removed delays after final EEPROM writes before exiting a method.
   Users are advised to wait enough time before interacting with the device again.
   Thanks to @David-OConnor for the suggestion.
@@ -28,7 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release to crates.io.
 
-[Unreleased]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/eldruin/mlx9061x-rs/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/eldruin/mlx9061x-rs/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Methods for reading tempature as a integer (`u16`).
+- Methods for reading temperature as a integer (`u16`).
   Users are advised to ONLY use these methods if running into to trouble using
   the standard temperature reading methods returning `f32` values as it's a more accurate read.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - [breaking-change] Transitioned `embedded-hal` to version 1.0
+- Add feature defmt-03
+- When feature enabled, "defmt::Format" is derived for any public struct or enum that derives Debug.
 
 ## [0.2.1] - 2023-06-02
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ smbus-pec = "1"
 
 [dev-dependencies]
 linux-embedded-hal = "0.4"
-embedded-hal-mock = { version = "0.10", features = ["eh1"] }
+embedded-hal-mock = { version = "0.10", default-features=false, features = ["eh1"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 edition = "2021"
 
 [features]
-defmt-03 = ["dep:defmt"]
+defmt-03 = ["dep:defmt", "embedded-hal/defmt-03"]
 
 [dependencies]
 embedded-hal = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,7 @@ smbus-pec = "1"
 
 [dev-dependencies]
 linux-embedded-hal = "0.4"
-embedded-hal-mock = { version = "0.10", default-features = false, features = [
-    "eh1",
-] }
+embedded-hal-mock = { version = "0.10", default-features = false, features = ["eh1"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlx9061x"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Diego Barrios Romero <eldruin@gmail.com>"]
 repository = "https://github.com/eldruin/mlx9061x-rs"
 license = "MIT OR Apache-2.0"
@@ -32,7 +32,9 @@ smbus-pec = "1"
 
 [dev-dependencies]
 linux-embedded-hal = "0.4"
-embedded-hal-mock = { version = "0.10", default-features=false, features = ["eh1"] }
+embedded-hal-mock = { version = "0.10", default-features = false, features = [
+    "eh1",
+] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,13 @@ repository = "https://github.com/eldruin/mlx9061x-rs"
 license = "MIT OR Apache-2.0"
 description = "Platform-agnostic Rust driver for the MLX90614 and MLX90615 non-contact infrared thermometers."
 readme = "README.md"
-keywords = ["infrared", "thermometer", "temperature", "sensor", "embedded-hal-driver"]
+keywords = [
+    "infrared",
+    "thermometer",
+    "temperature",
+    "sensor",
+    "embedded-hal-driver",
+]
 categories = ["embedded", "hardware-support", "no-std"]
 homepage = "https://github.com/eldruin/mlx9061x-rs"
 documentation = "https://docs.rs/mlx9061x"
@@ -18,15 +24,15 @@ include = [
     "/LICENSE-MIT",
     "/LICENSE-APACHE",
 ]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-embedded-hal = "0.2.5"
+embedded-hal = "1.0.0"
 smbus-pec = "1"
 
 [dev-dependencies]
-linux-embedded-hal = "0.3"
-embedded-hal-mock = "0.9"
+linux-embedded-hal = "0.4"
+embedded-hal-mock = { version = "0.10", features = ["eh1"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,13 @@ include = [
 ]
 edition = "2021"
 
+[features]
+defmt-03 = ["dep:defmt"]
+
 [dependencies]
 embedded-hal = "1.0.0"
 smbus-pec = "1"
+defmt = { version = "0.3.6", optional = true }
 
 [dev-dependencies]
 linux-embedded-hal = "0.4"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a platform agnostic Rust driver for the MLX90614/MLX90615 infrared
 thermometers using the [`embedded-hal`] traits.
 
 This driver allows you to:
+
 - Read the last object temperature measurement. See: `object1_temperature()`.
 - Read the last ambient temperature measurement. See: `ambient_temperature()`.
 - Read the last raw IR measurement. See: `raw_ir_channel1()`.
@@ -37,6 +38,7 @@ The readout resolution is 0.01°C (MLX90614) / 0.02°C (MLX90615).
 This driver uses the SMBus interface.
 
 Documentation:
+
 - Datasheets: [MLX90614](https://www.melexis.com/-/media/files/documents/datasheets/mlx90614-datasheet-melexis.pdf), [MLX90615](https://www.melexis.com/-/media/files/documents/datasheets/mlx90615-datasheet-melexis.pdf)
 - [SMBus communication with MLX90614](https://www.melexis.com/-/media/files/documents/application-notes/mlx90614-smbus-communication-application-note-melexis.pdf)
 
@@ -64,6 +66,40 @@ fn main() {
 }
 ```
 
+## Features
+
+### defmt-03
+
+defmt ("de format", short for "deferred formatting") is a highly efficient logging framework that targets resource-constrained devices, like microcontrollers. Learn more about defmt at [https://defmt.ferrous-systems.com].
+
+When feature "defmt-03" is enabled for the mlx9061x-rs dependency, defmt::Format is derived for most public struct and enum definitions. This allows (deferred-)formatting of data for logging and other reporting using the defmt crate. Data from the mlx9061x crate can then be logged alongside any other defmt-supported data using the normal defmt statements.
+
+To enable defmt support, when specifying a dependency on mlx9061x, add the feature "defmt-03"
+
+```toml
+[dependencies]
+mlx9061x = { version = "0.3.0", features = ["defmt-03"] }
+```
+
+#### defmt-03 usage
+
+```rust
+use linux_embedded_hal::I2cdev;
+use mlx9061x::{Mlx9061x, SlaveAddr};
+
+fn main() {
+    let dev = I2cdev::new("/dev/i2c-1").unwrap();
+    let addr = SlaveAddr::default();
+    let mut sensor = Mlx9061x::new_mlx90614(dev, addr, 5).unwrap();
+    loop {
+        match sensor.object1_temperature() {
+          Ok(obj_temp) => defmt::info!("Object temperature: {=f32}ºC", obj_temp),
+          Err(err) => defmt::error!("mlx9061x error {:?}", err),
+        }
+    }
+}
+```
+
 ## Support
 
 For questions, issues, feature requests, and other changes, please file an
@@ -73,10 +109,10 @@ For questions, issues, feature requests, and other changes, please file an
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+   <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+   <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@ use crate::{
     register_access::{mlx90614, mlx90615},
     Error, Mlx9061x, SlaveAddr,
 };
-use embedded_hal::blocking::{delay::DelayMs, i2c};
+use embedded_hal::{delay::DelayNs, i2c::I2c};
 
 impl<I2C, IC> Mlx9061x<I2C, IC> {
     /// Destroy driver instance, return I²C bus.
@@ -16,14 +16,14 @@ macro_rules! common {
     ($ic_marker:ident, $ic_reg:ident) => {
         impl<E, I2C> Mlx9061x<I2C, ic::$ic_marker>
         where
-            I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+            I2C: I2c<Error = E>,
         {
             /// Change the device address
             ///
             /// The address will be stored in the EEPROM.
             /// The address will be first cleared, before the new one is written.
             /// After each write the configured delay will be waited except the last time.
-            pub fn set_address<D: DelayMs<u8>>(
+            pub fn set_address<D: DelayNs>(
                 &mut self,
                 address: SlaveAddr,
                 delay_ms: &mut D,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@
 //! # }
 //! # impl I2c for I2c1 {
 //! #   type Error = ();
-//! #   fn read(&mut self, _: u8, _: &mut [u8]) -> Result<(), ())> { Ok(()) }
+//! #   fn read(&mut self, _: u8, _: &mut [u8]) -> Result<(), ()> { Ok(()) }
 //! #   fn write(&mut self, _: u8, _: &[u8]) -> Result<(), ()> { Ok(()) }
 //! #   fn write_read(&mut self, _: u8, _: &[u8], _: &mut[u8]) -> Result<(), ()> { Ok(()) }
 //! # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,8 +137,8 @@
 //! Note that the I2C pin construction/deconstruction depends on the HAL implementation.
 //!
 //! ```no_run
-//! # use embedded_hal::blocking::{delay::DelayMs, i2c};
-//! # use embedded_hal::digital::v2::OutputPin;
+//! # use embedded_hal::{delay::DelayNs, i2c::I2c};
+//! # use embedded_hal::digital::OutputPin;
 //! # struct IoPin;
 //! # impl OutputPin for IoPin {
 //! #   type Error = ();
@@ -150,13 +150,11 @@
 //! #   scl: IoPin,
 //! #   sda: IoPin
 //! # }
-//! # impl i2c::Write for I2c1 {
+//! # impl I2c for I2c1 {
 //! #   type Error = ();
-//! #   fn write(&mut self, addr: u8, data: &[u8]) -> Result<(), ()> { Ok(()) }
-//! # }
-//! # impl i2c::WriteRead for I2c1 {
-//! #   type Error = ();
-//! #   fn write_read(&mut self, addr: u8, data: &[u8], buf: &mut[u8]) -> Result<(), ()> { Ok(()) }
+//! #   fn read(&mut self, _: u8, _: &mut [u8]) -> Result<(), ())> { Ok(()) }
+//! #   fn write(&mut self, _: u8, _: &[u8]) -> Result<(), ()> { Ok(()) }
+//! #   fn write_read(&mut self, _: u8, _: &[u8], _: &mut[u8]) -> Result<(), ()> { Ok(()) }
 //! # }
 //! #
 //! # impl I2c1 {
@@ -171,8 +169,10 @@
 //! # }
 //! #
 //! # struct Delay;
-//! # impl DelayMs<u8> for Delay {
-//! #   fn delay_ms(&mut self, _: u8) {}
+//! # impl DelayNs for Delay {
+//! #   fn delay_ns(&mut self, _: u32) {}
+//! #   fn delay_us(&mut self, _: u32) {}
+//! #   fn delay_ms(&mut self, mut _: u32) {}
 //! # }
 //! # let sda = IoPin;
 //! # let scl = IoPin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ mod register_access;
 pub struct Mlx9061x<I2C, IC> {
     /// The concrete I²C device implementation.
     i2c: I2C,
-    eeprom_write_delay_ms: u32,
+    eeprom_write_delay_ms: u8,
     address: u8,
     _ic: PhantomData<IC>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ mod register_access;
 pub struct Mlx9061x<I2C, IC> {
     /// The concrete I²C device implementation.
     i2c: I2C,
-    eeprom_write_delay_ms: u8,
+    eeprom_write_delay_ms: u32,
     address: u8,
     _ic: PhantomData<IC>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,13 +137,17 @@
 //! Note that the I2C pin construction/deconstruction depends on the HAL implementation.
 //!
 //! ```no_run
-//! # use embedded_hal::{delay::DelayNs, i2c::I2c};
-//! # use embedded_hal::digital::OutputPin;
+//! # use embedded_hal::{delay::DelayNs, i2c::{self, I2c}};
+//! # use embedded_hal::digital::{self, OutputPin};
+//! # use core::convert::Infallible;
 //! # struct IoPin;
 //! # impl OutputPin for IoPin {
-//! #   type Error = ();
-//! #   fn set_high(&mut self) -> Result<(), ()> { Ok(()) }
-//! #   fn set_low(&mut self) -> Result<(), ()> { Ok(()) }
+//! #   fn set_high(&mut self) -> Result<(), Infallible> { Ok(()) }
+//! #   fn set_low(&mut self) -> Result<(), Infallible> { Ok(()) }
+//! # }
+//! #
+//! # impl digital::ErrorType for IoPin {
+//! #     type Error = Infallible;
 //! # }
 //! #
 //! # struct I2c1 {
@@ -151,10 +155,14 @@
 //! #   sda: IoPin
 //! # }
 //! # impl I2c for I2c1 {
-//! #   type Error = ();
-//! #   fn read(&mut self, _: u8, _: &mut [u8]) -> Result<(), ()> { Ok(()) }
-//! #   fn write(&mut self, _: u8, _: &[u8]) -> Result<(), ()> { Ok(()) }
-//! #   fn write_read(&mut self, _: u8, _: &[u8], _: &mut[u8]) -> Result<(), ()> { Ok(()) }
+//! #   fn read(&mut self, _: u8, _: &mut [u8]) -> Result<(), Infallible> { Ok(()) }
+//! #   fn write(&mut self, _: u8, _: &[u8]) -> Result<(), Infallible> { Ok(()) }
+//! #   fn write_read(&mut self, _: u8, _: &[u8], _: &mut[u8]) -> Result<(), Infallible> { Ok(()) }
+//! #   fn transaction(&mut self, _: u8, _: &mut [i2c::Operation<'_>]) -> Result<(), Infallible> { Ok(()) }
+//! # }
+//! #
+//! # impl i2c::ErrorType for I2c1 {
+//! #     type Error = Infallible;
 //! # }
 //! #
 //! # impl I2c1 {
@@ -172,7 +180,7 @@
 //! # impl DelayNs for Delay {
 //! #   fn delay_ns(&mut self, _: u32) {}
 //! #   fn delay_us(&mut self, _: u32) {}
-//! #   fn delay_ms(&mut self, mut _: u32) {}
+//! #   fn delay_ms(&mut self, _: u32) {}
 //! # }
 //! # let sda = IoPin;
 //! # let scl = IoPin;

--- a/src/mlx90614.rs
+++ b/src/mlx90614.rs
@@ -146,6 +146,6 @@ pub fn wake_mlx90614<E, SclPin: OutputPin<Error = E>, SdaPin: OutputPin<Error = 
 ) -> Result<(), E> {
     scl.set_high()?;
     sda.set_low()?;
-    delay.delay_ms(mlx90614::WAKE_DELAY_MS);
+    delay.delay_ms(mlx90614::WAKE_DELAY_MS as u32);
     sda.set_high()
 }

--- a/src/mlx90614.rs
+++ b/src/mlx90614.rs
@@ -6,14 +6,11 @@ use crate::{
     Error, Mlx9061x, SlaveAddr,
 };
 use core::marker::PhantomData;
-use embedded_hal::{
-    blocking::{delay::DelayMs, i2c},
-    digital::v2::OutputPin,
-};
+use embedded_hal::{delay::DelayNs, digital::OutputPin, i2c::I2c};
 
 impl<E, I2C> Mlx9061x<I2C, ic::Mlx90614>
 where
-    I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Create new instance of the MLX90614 device.
     ///
@@ -27,7 +24,7 @@ where
     pub fn new_mlx90614(
         i2c: I2C,
         address: SlaveAddr,
-        eeprom_write_delay_ms: u8,
+        eeprom_write_delay_ms: u32,
     ) -> Result<Self, Error<E>> {
         let address = Self::get_address(address, DEV_ADDR)?;
         Ok(Mlx9061x {
@@ -112,7 +109,7 @@ where
     /// Set emissivity epsilon [0.1-1.0]
     ///
     /// Wrong values will return `Error::InvalidInputData`.
-    pub fn set_emissivity<D: DelayMs<u8>>(
+    pub fn set_emissivity<D: DelayNs>(
         &mut self,
         epsilon: f32,
         delay: &mut D,
@@ -142,12 +139,7 @@ where
 /// Wake device from sleep mode.
 ///
 /// Note that this includes a 33ms delay.
-pub fn wake_mlx90614<
-    E,
-    SclPin: OutputPin<Error = E>,
-    SdaPin: OutputPin<Error = E>,
-    D: DelayMs<u8>,
->(
+pub fn wake_mlx90614<E, SclPin: OutputPin<Error = E>, SdaPin: OutputPin<Error = E>, D: DelayNs>(
     scl: &mut SclPin,
     sda: &mut SdaPin,
     delay: &mut D,

--- a/src/mlx90614.rs
+++ b/src/mlx90614.rs
@@ -24,7 +24,7 @@ where
     pub fn new_mlx90614(
         i2c: I2C,
         address: SlaveAddr,
-        eeprom_write_delay_ms: u32,
+        eeprom_write_delay_ms: u8,
     ) -> Result<Self, Error<E>> {
         let address = Self::get_address(address, DEV_ADDR)?;
         Ok(Mlx9061x {

--- a/src/mlx90615.rs
+++ b/src/mlx90615.rs
@@ -114,6 +114,6 @@ pub fn wake_mlx90615<E, P: OutputPin<Error = E>, D: DelayNs>(
     delay: &mut D,
 ) -> Result<(), E> {
     scl.set_low()?;
-    delay.delay_ms(mlx90615::WAKE_DELAY_MS);
+    delay.delay_ms(mlx90615::WAKE_DELAY_MS as u32);
     scl.set_high()
 }

--- a/src/mlx90615.rs
+++ b/src/mlx90615.rs
@@ -4,14 +4,11 @@ use crate::{
     Error, Mlx9061x, SlaveAddr,
 };
 use core::marker::PhantomData;
-use embedded_hal::{
-    blocking::{delay::DelayMs, i2c},
-    digital::v2::OutputPin,
-};
+use embedded_hal::{delay::DelayNs, digital::OutputPin, i2c::I2c};
 
 impl<E, I2C> Mlx9061x<I2C, ic::Mlx90615>
 where
-    I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Create new instance of the MLX90615 device.
     ///
@@ -25,7 +22,7 @@ where
     pub fn new_mlx90615(
         i2c: I2C,
         address: SlaveAddr,
-        eeprom_write_delay_ms: u8,
+        eeprom_write_delay_ms: u32,
     ) -> Result<Self, Error<E>> {
         let address = Self::get_address(address, DEV_ADDR)?;
         Ok(Mlx9061x {
@@ -39,7 +36,7 @@ where
 
 impl<E, I2C> Mlx9061x<I2C, ic::Mlx90615>
 where
-    I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Read the ambient temperature in celsius degrees
     pub fn ambient_temperature(&mut self) -> Result<f32, Error<E>> {
@@ -89,7 +86,7 @@ where
     /// Set emissivity epsilon [0.0-1.0]
     ///
     /// Wrong values will return `Error::InvalidInputData`.
-    pub fn set_emissivity<D: DelayMs<u8>>(
+    pub fn set_emissivity<D: DelayNs>(
         &mut self,
         epsilon: f32,
         delay: &mut D,
@@ -112,7 +109,7 @@ where
 /// Wake device from sleep mode.
 ///
 /// Note that this includes a 39ms delay.
-pub fn wake_mlx90615<E, P: OutputPin<Error = E>, D: DelayMs<u8>>(
+pub fn wake_mlx90615<E, P: OutputPin<Error = E>, D: DelayNs>(
     scl: &mut P,
     delay: &mut D,
 ) -> Result<(), E> {

--- a/src/mlx90615.rs
+++ b/src/mlx90615.rs
@@ -22,7 +22,7 @@ where
     pub fn new_mlx90615(
         i2c: I2C,
         address: SlaveAddr,
-        eeprom_write_delay_ms: u32,
+        eeprom_write_delay_ms: u8,
     ) -> Result<Self, Error<E>> {
         let address = Self::get_address(address, DEV_ADDR)?;
         Ok(Mlx9061x {

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -5,7 +5,7 @@ use smbus_pec::pec;
 pub mod mlx90614 {
     const EEPROM_COMMAND: u8 = 0x20;
     pub const SLEEP_COMMAND: u8 = 0xFF;
-    pub const WAKE_DELAY_MS: u32 = 33;
+    pub const WAKE_DELAY_MS: u8 = 33;
     pub const DEV_ADDR: u8 = 0x5A;
     pub struct Register {}
     impl Register {

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -83,7 +83,7 @@ where
         delay: &mut D,
     ) -> Result<(), Error<E>> {
         self.write_u16(command, 0)?;
-        delay.delay_ms(self.eeprom_write_delay_ms);
+        delay.delay_ms(self.eeprom_write_delay_ms as u32);
         self.write_u16(command, data)
     }
 

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -24,7 +24,7 @@ pub mod mlx90615 {
     const EEPROM_COMMAND: u8 = 0x10;
     const RAM_COMMAND: u8 = 0x20;
     pub const SLEEP_COMMAND: u8 = 0xC6;
-    pub const WAKE_DELAY_MS: u32 = 39;
+    pub const WAKE_DELAY_MS: u8 = 39;
     pub const DEV_ADDR: u8 = 0x5B;
     pub struct Register {}
     impl Register {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 /// All possible errors in this crate
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Debug)]
 pub enum Error<E> {
     /// I²C bus error
@@ -18,6 +19,7 @@ pub mod ic {
 }
 
 /// Possible slave addresses
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SlaveAddr {
     /// Default slave address

--- a/tests/base/mod.rs
+++ b/tests/base/mod.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
+use embedded_hal_mock::eh1::i2c::{Mock as I2cMock, Transaction as I2cTrans};
 use mlx9061x::{ic, Mlx9061x, SlaveAddr};
 
 #[allow(unused)]

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -15,14 +15,17 @@ macro_rules! tests {
         }
 
         #[test]
-        fn wrong_address_raises_error() {
+        fn address_below_minimum_raises_error() {
             let mut below_min_mock = I2cMock::new(&[]);
             assert_error!(
                 Mlx9061x::$create(below_min_mock.clone(), SlaveAddr::Alternative(0), 5),
                 InvalidInputData
             );
             below_min_mock.done();
+        }
 
+        #[test]
+        fn address_above_maximum_raises_error() {
             let mut above_max_mock = I2cMock::new(&[]);
             assert_error!(
                 Mlx9061x::$create(above_max_mock.clone(), SlaveAddr::Alternative(128), 5),

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,7 +1,7 @@
 mod base;
 use crate::base::{destroy, mlx90614, mlx90615, new_mlx90614, new_mlx90615};
-use embedded_hal_mock::{
-    delay::MockNoop as NoopDelay,
+use embedded_hal_mock::eh1::{
+    delay::NoopDelay,
     i2c::{Mock as I2cMock, Transaction as I2cTrans},
 };
 use mlx9061x::{Error, Mlx9061x, SlaveAddr};

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -16,14 +16,19 @@ macro_rules! tests {
 
         #[test]
         fn wrong_address_raises_error() {
+            let mut below_min_mock = I2cMock::new(&[]);
             assert_error!(
-                Mlx9061x::$create(I2cMock::new(&[]), SlaveAddr::Alternative(0), 5),
+                Mlx9061x::$create(below_min_mock.clone(), SlaveAddr::Alternative(0), 5),
                 InvalidInputData
             );
+            below_min_mock.done();
+
+            let mut above_max_mock = I2cMock::new(&[]);
             assert_error!(
-                Mlx9061x::$create(I2cMock::new(&[]), SlaveAddr::Alternative(128), 5),
+                Mlx9061x::$create(above_max_mock.clone(), SlaveAddr::Alternative(128), 5),
                 InvalidInputData
             );
+            above_max_mock.done();
         }
 
         #[test]

--- a/tests/mlx90614.rs
+++ b/tests/mlx90614.rs
@@ -1,7 +1,7 @@
 mod base;
 use crate::base::{destroy, mlx90614, mlx90614::Register as Reg, new_mlx90614};
-use embedded_hal_mock::{
-    delay::MockNoop as NoopDelay,
+use embedded_hal_mock::eh1::{
+    delay::NoopDelay,
     i2c::Transaction as I2cTrans,
     pin::{Mock as PinMock, State as PinState, Transaction as PinTrans},
 };

--- a/tests/mlx90615.rs
+++ b/tests/mlx90615.rs
@@ -1,7 +1,7 @@
 mod base;
 use crate::base::{destroy, mlx90615, mlx90615::Register as Reg, new_mlx90615};
-use embedded_hal_mock::{
-    delay::MockNoop as NoopDelay,
+use embedded_hal_mock::eh1::{
+    delay::NoopDelay,
     i2c::Transaction as I2cTrans,
     pin::{Mock as PinMock, State as PinState, Transaction as PinTrans},
 };


### PR DESCRIPTION
This updates to use the embedded_hal 1.0, which has breaking changes in the i2c and digital::OutputPin interfaces. Also updates to the matching versions of linux_embedded_hal, and embedded_hal_mock.
Cargo edition pulled forward to 2021.

Fixes #7 