### PR TITLE
Fix raw IR channel readout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Initial release to crates.io.
 
 <!-- next-url -->
-
 [Unreleased]: https://github.com/eldruin/mlx9061x-rs/compare/v0.3.0...HEAD
 
 [0.3.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.1...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add `read_i16()` to get accurate reading of raw values for objects colder than the sensor.
+
 ## [0.3.0] - 2024-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
-
 ## [Unreleased] - ReleaseDate
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased] - ReleaseDate
 
-### Added
+### Changed
 
 - [breaking-change] Changed return type of the `raw_ir`, `raw_ir_channel1` and `raw_ir_channel2` method to `i16` to fix
   a readout conversion error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- [breaking-change] Changed return type of the `raw_ir`, `raw_ir_channel1` and `raw_ir_channel2` method to `i16` to fix
+- [breaking-change] Changed return type of the `raw_ir`, `raw_ir_channel1` and `raw_ir_channel2` methods to `i16` to fix
   a readout conversion error.
 
 ## [0.3.0] - 2024-05-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Initial release to crates.io.
 [Unreleased]: https://github.com/eldruin/mlx9061x-rs/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.0...v0.2.1
-
 [0.2.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.1.0...v0.2.0
 
 [0.1.0]: https://github.com/eldruin/mlx9061x-rs/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ Initial release to crates.io.
 <!-- next-url -->
 [Unreleased]: https://github.com/eldruin/mlx9061x-rs/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.1...v0.3.0
-
 [0.2.1]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.0...v0.2.1
 
 [0.2.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,6 @@ Initial release to crates.io.
 
 <!-- next-url -->
 [Unreleased]: https://github.com/eldruin/mlx9061x-rs/compare/v0.3.0...HEAD
-
 [0.3.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.1...v0.3.0
 
 [0.2.1]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,5 +52,4 @@ Initial release to crates.io.
 [0.3.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.1.0...v0.2.0
-
 [0.1.0]: https://github.com/eldruin/mlx9061x-rs/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
+
 ## [Unreleased] - ReleaseDate
 
 ### Added
 
-- Add `read_i16()` to get accurate reading of raw values for objects colder than the sensor.
+- [breaking-change] Changed return type of the `raw_ir`, `raw_ir_channel1` and `raw_ir_channel2` method to `i16` to fix
+  a readout conversion error.
 
 ## [0.3.0] - 2024-05-23
 
@@ -47,8 +49,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Initial release to crates.io.
 
 <!-- next-url -->
+
 [Unreleased]: https://github.com/eldruin/mlx9061x-rs/compare/v0.3.0...HEAD
+
 [0.3.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.1...v0.3.0
+
 [0.2.1]: https://github.com/eldruin/mlx9061x-rs/compare/v0.2.0...v0.2.1
+
 [0.2.0]: https://github.com/eldruin/mlx9061x-rs/compare/v0.1.0...v0.2.0
+
 [0.1.0]: https://github.com/eldruin/mlx9061x-rs/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ smbus-pec = "1"
 defmt = { version = "0.3.6", optional = true }
 
 [dev-dependencies]
-linux-embedded-hal = "0.4"
 embedded-hal-mock = { version = "0.10", default-features = false, features = ["eh1"] }
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+linux-embedded-hal = "0.4"
 
 [profile.release]
 lto = true

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -1,6 +1,9 @@
+#[cfg(target_os = "linux")]
 use linux_embedded_hal::I2cdev;
+#[cfg(target_os = "linux")]
 use mlx9061x::{Mlx9061x, SlaveAddr};
 
+#[cfg(target_os = "linux")]
 fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
     let addr = SlaveAddr::default();
@@ -9,4 +12,9 @@ fn main() {
         let obj_temp = sensor.object1_temperature().unwrap();
         println!("Object temperature: {:.2}ºC", obj_temp);
     }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    panic!("This example can only be run on Linux.");
 }

--- a/src/mlx90614.rs
+++ b/src/mlx90614.rs
@@ -91,13 +91,13 @@ where
     }
 
     /// Read the channel 1 raw IR data
-    pub fn raw_ir_channel1(&mut self) -> Result<u16, Error<E>> {
-        self.read_u16(Register::RAW_IR1)
+    pub fn raw_ir_channel1(&mut self) -> Result<i16, Error<E>> {
+        self.read_i16(Register::RAW_IR1)
     }
 
     /// Read the channel 2 raw IR data
-    pub fn raw_ir_channel2(&mut self) -> Result<u16, Error<E>> {
-        self.read_u16(Register::RAW_IR2)
+    pub fn raw_ir_channel2(&mut self) -> Result<i16, Error<E>> {
+        self.read_i16(Register::RAW_IR2)
     }
 
     /// Get emissivity epsilon

--- a/src/mlx90615.rs
+++ b/src/mlx90615.rs
@@ -73,8 +73,8 @@ where
     }
 
     /// Read the raw IR data
-    pub fn raw_ir(&mut self) -> Result<u16, Error<E>> {
-        self.read_u16(Register::RAW_IR)
+    pub fn raw_ir(&mut self) -> Result<i16, Error<E>> {
+        self.read_i16(Register::RAW_IR)
     }
 
     /// Get emissivity epsilon

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -88,7 +88,6 @@ where
     /// - The highest bit of the MSB is used to determine the sign (positive or negative).
 
     pub fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
-        // Extract the sign bit from the MSB
         let sign_bit = msb & 0b10000000;
 
         // Combine the remaining bits from MSB and LSB

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -64,29 +64,6 @@ where
         Ok(u16::from(data[0]) | (u16::from(data[1]) << 8))
     }
 
-    /// Converts the provided MSB (Most Significant Byte) and LSB (Least Significant Byte)
-    /// into a signed 16-bit integer in sign-magnitude format.
-    ///
-    /// # Sign-Magnitude Representation:
-    /// The sign-magnitude format represents the sign of the number in the most significant bit (MSB).
-    /// - If the MSB's most significant bit is set (1), the number is negative.
-    /// - If the MSB's most significant bit is clear (0), the number is positive.
-    ///
-    /// The remaining 15 bits represent the magnitude of the number.
-    ///
-    /// # Parameters:
-    /// - `msb`: The Most Significant Byte (MSB) of the 16-bit number.
-    /// - `lsb`: The Least Significant Byte (LSB) of the 16-bit number.
-    ///
-    /// # Returns:
-    /// An `i16` value representing the signed 16-bit integer in sign-magnitude format.
-    /// - Positive values if the MSB's most significant bit is 0.
-    /// - Negative values if the MSB's most significant bit is 1.
-    ///
-    /// # Notes:
-    /// - This method assumes the input values are in sign-magnitude format.
-    /// - The highest bit of the MSB is used to determine the sign (positive or negative).
-
     pub fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
         let sign_bit = msb & 0b1000_0000;
 

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -64,6 +64,29 @@ where
         Ok(u16::from(data[0]) | (u16::from(data[1]) << 8))
     }
 
+    /// Converts the provided MSB (Most Significant Byte) and LSB (Least Significant Byte)
+    /// into a signed 16-bit integer in sign-magnitude format.
+    ///
+    /// # Sign-Magnitude Representation:
+    /// The sign-magnitude format represents the sign of the number in the most significant bit (MSB).
+    /// - If the MSB's most significant bit is set (1), the number is negative.
+    /// - If the MSB's most significant bit is clear (0), the number is positive.
+    ///
+    /// The remaining 15 bits represent the magnitude of the number.
+    ///
+    /// # Parameters:
+    /// - `msb`: The Most Significant Byte (MSB) of the 16-bit number.
+    /// - `lsb`: The Least Significant Byte (LSB) of the 16-bit number.
+    ///
+    /// # Returns:
+    /// An `i16` value representing the signed 16-bit integer in sign-magnitude format.
+    /// - Positive values if the MSB's most significant bit is 0.
+    /// - Negative values if the MSB's most significant bit is 1.
+    ///
+    /// # Notes:
+    /// - This method assumes the input values are in sign-magnitude format.
+    /// - The highest bit of the MSB is used to determine the sign (positive or negative).
+
     pub fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
         // Extract the sign bit from the MSB
         let sign_bit = msb & 0b10000000;

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -91,7 +91,7 @@ where
         let sign_bit = msb & 0b1000_0000;
 
         // Combine the remaining bits from MSB and LSB
-        let value = ((msb & 0b01111111) as i16) << 8 | lsb as i16;
+        let value = ((msb & 0b0111_1111) as i16) << 8 | lsb as i16;
 
         if sign_bit != 0 {
             -value

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -7,7 +7,9 @@ pub mod mlx90614 {
     pub const SLEEP_COMMAND: u8 = 0xFF;
     pub const WAKE_DELAY_MS: u8 = 33;
     pub const DEV_ADDR: u8 = 0x5A;
+
     pub struct Register {}
+
     impl Register {
         pub const RAW_IR1: u8 = 0x04;
         pub const RAW_IR2: u8 = 0x05;
@@ -26,7 +28,9 @@ pub mod mlx90615 {
     pub const SLEEP_COMMAND: u8 = 0xC6;
     pub const WAKE_DELAY_MS: u8 = 39;
     pub const DEV_ADDR: u8 = 0x5B;
+
     pub struct Register {}
+
     impl Register {
         pub const RAW_IR: u8 = 0x05 | RAM_COMMAND;
         pub const TA: u8 = 0x06 | RAM_COMMAND;
@@ -58,6 +62,40 @@ where
             pec,
         )?;
         Ok(u16::from(data[0]) | (u16::from(data[1]) << 8))
+    }
+
+    fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
+        // Extract the sign bit from the MSB
+        let sign_bit = msb & 0b10000000;
+
+        // Combine the remaining bits from MSB and LSB
+        let value = ((msb & 0b01111111) as i16) << 8 | lsb as i16;
+
+        // If the sign bit is set, make the value negative
+        if sign_bit != 0 {
+            -value
+        } else {
+            value
+        }
+    }
+
+    pub(crate) fn read_i16(&mut self, register: u8) -> Result<i16, Error<E>> {
+        let mut data = [0; 3];
+        self.i2c
+            .write_read(self.address, &[register], &mut data)
+            .map_err(Error::I2C)?;
+        let pec = data[2];
+        Self::check_pec(
+            &[
+                self.address << 1,
+                register,
+                (self.address << 1) + 1,
+                data[0],
+                data[1],
+            ],
+            pec,
+        )?;
+        Ok(self.msb_lsb_to_sign_magnitude(data[0], data[1]))
     }
 
     pub(crate) fn write_u8(&mut self, command: u8) -> Result<(), Error<E>> {

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -160,6 +160,6 @@ mod msb_lsb_to_sign_magnitude_tests {
     msb_lsb_to_sign_magnitude_test!(test_msb_lsb_negative_258, 0x81, 0x02, -258);
 
     msb_lsb_to_sign_magnitude_test!(test_msb_lsb_negative_32767, 0xFF, 0xFF, -32767);
-    
+
     msb_lsb_to_sign_magnitude_test!(test_msb_lsb_negative_one, 0x80, 0x01, -1);
 }

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -64,7 +64,7 @@ where
         Ok(u16::from(data[0]) | (u16::from(data[1]) << 8))
     }
 
-    fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
+    pub(crate) fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
         // Extract the sign bit from the MSB
         let sign_bit = msb & 0b10000000;
 

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -95,7 +95,7 @@ where
             ],
             pec,
         )?;
-        Ok(self.msb_lsb_to_sign_magnitude(data[0], data[1]))
+        Ok(self.msb_lsb_to_sign_magnitude(data[1], data[0]))
     }
 
     pub(crate) fn write_u8(&mut self, command: u8) -> Result<(), Error<E>> {

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -88,13 +88,17 @@ where
     /// - The highest bit of the MSB is used to determine the sign (positive or negative).
 
     pub fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
-        let magnitude = ((msb as u16 & 0x7F) << 8) | lsb as u16; // Extract magnitude (lower 15 bits)
-        if msb & 0x80 != 0 {
-            // MSB is set, so it's negative
-            -(magnitude as i16)
+        // Extract the sign bit from the MSB
+        let sign_bit = msb & 0b10000000;
+
+        // Combine the remaining bits from MSB and LSB
+        let value = ((msb & 0b01111111) as i16) << 8 | lsb as i16;
+
+        // If the sign bit is set, make the value negative
+        if sign_bit != 0 {
+            -value
         } else {
-            // MSB is not set, so it's positive
-            magnitude as i16
+            value
         }
     }
 

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -93,7 +93,6 @@ where
         // Combine the remaining bits from MSB and LSB
         let value = ((msb & 0b01111111) as i16) << 8 | lsb as i16;
 
-        // If the sign bit is set, make the value negative
         if sign_bit != 0 {
             -value
         } else {

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -67,7 +67,6 @@ where
     pub fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
         let sign_bit = msb & 0b1000_0000;
 
-        // Combine the remaining bits from MSB and LSB
         let value = ((msb & 0b0111_1111) as i16) << 8 | lsb as i16;
 
         if sign_bit != 0 {

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -88,7 +88,7 @@ where
     /// - The highest bit of the MSB is used to determine the sign (positive or negative).
 
     pub fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
-        let sign_bit = msb & 0b10000000;
+        let sign_bit = msb & 0b1000_0000;
 
         // Combine the remaining bits from MSB and LSB
         let value = ((msb & 0b01111111) as i16) << 8 | lsb as i16;

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -88,17 +88,13 @@ where
     /// - The highest bit of the MSB is used to determine the sign (positive or negative).
 
     pub fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
-        // Extract the sign bit from the MSB
-        let sign_bit = msb & 0b10000000;
-
-        // Combine the remaining bits from MSB and LSB
-        let value = ((msb & 0b01111111) as i16) << 8 | lsb as i16;
-
-        // If the sign bit is set, make the value negative
-        if sign_bit != 0 {
-            -value
+        let magnitude = ((msb as u16 & 0x7F) << 8) | lsb as u16; // Extract magnitude (lower 15 bits)
+        if msb & 0x80 != 0 {
+            // MSB is set, so it's negative
+            -(magnitude as i16)
         } else {
-            value
+            // MSB is not set, so it's positive
+            magnitude as i16
         }
     }
 

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -64,7 +64,7 @@ where
         Ok(u16::from(data[0]) | (u16::from(data[1]) << 8))
     }
 
-    pub(crate) fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
+    pub fn msb_lsb_to_sign_magnitude(&self, msb: u8, lsb: u8) -> i16 {
         // Extract the sign bit from the MSB
         let sign_bit = msb & 0b10000000;
 

--- a/tests/base/mod.rs
+++ b/tests/base/mod.rs
@@ -108,3 +108,20 @@ macro_rules! read_u16_test {
         }
     };
 }
+
+#[macro_export]
+macro_rules! read_i16_test {
+    ($name:ident, $create:ident, $address:expr, $method:ident, $reg:expr, $data0:expr, $data1:expr, $data2:expr, $expected:expr) => {
+        #[test]
+        fn $name() {
+            let mut sensor = $create(&[I2cTrans::write_read(
+                $address,
+                vec![$reg],
+                vec![$data0, $data1, $data2],
+            )]);
+            let t = sensor.$method().unwrap();
+            assert_eq!(t, $expected);
+            destroy(sensor);
+        }
+    };
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -103,15 +103,61 @@ macro_rules! msb_lsb_to_sign_magnitude_test {
 
 mod msb_lsb_to_sign_magnitude_tests {
     use super::*;
-    use crate::base::new_mlx90614;
+    use crate::base::{destroy, new_mlx90614};
 
-    // Test cases using the new macro
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_zero, new_mlx90614, 0x00, 0x00, 0);
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_positive_258, new_mlx90614, 0x01, 0x02, 258);
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_max_positive, new_mlx90614, 0x7F, 0xFF, 32767);
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_min_negative, new_mlx90614, 0x80, 0x00, -32768);
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_negative_258, new_mlx90614, 0x81, 0x02, -258);
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_negative_one, new_mlx90614, 0xFF, 0xFF, -1);
+    // Test case for zero (0x00, 0x00)
+    msb_lsb_to_sign_magnitude_test!(
+        test_msb_lsb_zero,
+        new_mlx90614,
+        0x00,
+        0x00,
+        0
+    );
+
+    // Test case for small positive value (0x01, 0x02 -> 258)
+    msb_lsb_to_sign_magnitude_test!(
+        test_msb_lsb_positive_258,
+        new_mlx90614,
+        0x01,
+        0x02,
+        258
+    );
+
+    // Test case for maximum positive value (0x7F, 0xFF -> 32767)
+    msb_lsb_to_sign_magnitude_test!(
+        test_msb_lsb_max_positive,
+        new_mlx90614,
+        0x7F,
+        0xFF,
+        32767
+    );
+
+    // Test case for minimum negative value (0x80, 0x00 -> -32768)
+    msb_lsb_to_sign_magnitude_test!(
+        test_msb_lsb_min_negative,
+        new_mlx90614,
+        0x80,
+        0x00,
+        -32768
+    );
+
+    // Test case for a small negative value (0x81, 0x02 -> -258)
+    msb_lsb_to_sign_magnitude_test!(
+        test_msb_lsb_negative_258,
+        new_mlx90614,
+        0x81,
+        0x02,
+        -258
+    );
+
+    // Test case for -1 (0xFF, 0xFF -> -1)
+    msb_lsb_to_sign_magnitude_test!(
+        test_msb_lsb_negative_one,
+        new_mlx90614,
+        0xFF,
+        0xFF,
+        -1
+    );
 }
 
 mod mlx90614_tests {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -138,7 +138,7 @@ mod msb_lsb_to_sign_magnitude_tests {
         new_mlx90614,
         0x80,
         0x00,
-        -32768
+        -0
     );
 
     // Test case for a small negative value (0x81, 0x02 -> -258)
@@ -156,7 +156,7 @@ mod msb_lsb_to_sign_magnitude_tests {
         new_mlx90614,
         0xFF,
         0xFF,
-        -1
+        -32767
     );
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -77,53 +77,6 @@ macro_rules! tests {
     };
 }
 
-#[macro_export]
-macro_rules! msb_lsb_to_sign_magnitude_test {
-    ($name:ident, $create:ident, $msb:expr, $lsb:expr, $expected:expr) => {
-        #[test]
-        fn $name() {
-            // Initialize the sensor with no I2C transactions
-            let sensor = $create(&[]);
-
-            // Run the test case
-            let result = sensor.msb_lsb_to_sign_magnitude($msb, $lsb);
-
-            // Assert that the result matches the expected value
-            assert_eq!(
-                result, $expected,
-                "For MSB: {:#X}, LSB: {:#X}, expected: {}, got: {}",
-                $msb, $lsb, $expected, result
-            );
-
-            // Cleanup
-            destroy(sensor);
-        }
-    };
-}
-
-mod msb_lsb_to_sign_magnitude_tests {
-    use super::*;
-    use crate::base::{destroy, new_mlx90614};
-
-    // Test case for zero (0x00, 0x00)
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_zero, new_mlx90614, 0x00, 0x00, 0);
-
-    // Test case for small positive value (0x01, 0x02 -> 258)
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_positive_258, new_mlx90614, 0x01, 0x02, 258);
-
-    // Test case for maximum positive value (0x7F, 0xFF -> 32767)
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_max_positive, new_mlx90614, 0x7F, 0xFF, 32767);
-
-    // Test case for minimum negative value (0x80, 0x00 -> -32768)
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_min_negative, new_mlx90614, 0x80, 0x00, -0);
-
-    // Test case for a small negative value (0x81, 0x02 -> -258)
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_negative_258, new_mlx90614, 0x81, 0x02, -258);
-
-    // Test case for -1 (0xFF, 0xFF -> -1)
-    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_negative_one, new_mlx90614, 0xFF, 0xFF, -32767);
-}
-
 mod mlx90614_tests {
     use super::*;
     tests!(new_mlx90614, mlx90614);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -74,7 +74,41 @@ macro_rules! tests {
             );
             destroy(sensor);
         }
+
     };
+}
+
+#[macro_export]
+macro_rules! msb_lsb_to_sign_magnitude_test {
+    ($name:ident, $create:ident, $msb:expr, $lsb:expr, $expected:expr) => {
+        #[test]
+        fn $name() {
+            // Initialize the sensor with no I2C transactions
+            let mut sensor = $create(&[]);
+
+            // Run the test case
+            let result = sensor.msb_lsb_to_sign_magnitude($msb, $lsb);
+
+            // Assert that the result matches the expected value
+            assert_eq!(result, $expected, "For MSB: {:#X}, LSB: {:#X}, expected: {}, got: {}", $msb, $lsb, $expected, result);
+
+            // Cleanup
+            destroy(sensor);
+        }
+    };
+}
+
+mod msb_lsb_to_sign_magnitude_tests {
+    use super::*;
+    use crate::base::new_mlx90614;
+
+    // Test cases using the new macro
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_zero, new_mlx90614, 0x00, 0x00, 0);
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_positive_258, new_mlx90614, 0x01, 0x02, 258);
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_max_positive, new_mlx90614, 0x7F, 0xFF, 32767);
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_min_negative, new_mlx90614, 0x80, 0x00, -32768);
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_negative_258, new_mlx90614, 0x81, 0x02, -258);
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_negative_one, new_mlx90614, 0xFF, 0xFF, -1);
 }
 
 mod mlx90614_tests {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -74,7 +74,6 @@ macro_rules! tests {
             );
             destroy(sensor);
         }
-
     };
 }
 
@@ -90,7 +89,11 @@ macro_rules! msb_lsb_to_sign_magnitude_test {
             let result = sensor.msb_lsb_to_sign_magnitude($msb, $lsb);
 
             // Assert that the result matches the expected value
-            assert_eq!(result, $expected, "For MSB: {:#X}, LSB: {:#X}, expected: {}, got: {}", $msb, $lsb, $expected, result);
+            assert_eq!(
+                result, $expected,
+                "For MSB: {:#X}, LSB: {:#X}, expected: {}, got: {}",
+                $msb, $lsb, $expected, result
+            );
 
             // Cleanup
             destroy(sensor);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -83,7 +83,7 @@ macro_rules! msb_lsb_to_sign_magnitude_test {
         #[test]
         fn $name() {
             // Initialize the sensor with no I2C transactions
-            let mut sensor = $create(&[]);
+            let sensor = $create(&[]);
 
             // Run the test case
             let result = sensor.msb_lsb_to_sign_magnitude($msb, $lsb);
@@ -106,58 +106,22 @@ mod msb_lsb_to_sign_magnitude_tests {
     use crate::base::{destroy, new_mlx90614};
 
     // Test case for zero (0x00, 0x00)
-    msb_lsb_to_sign_magnitude_test!(
-        test_msb_lsb_zero,
-        new_mlx90614,
-        0x00,
-        0x00,
-        0
-    );
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_zero, new_mlx90614, 0x00, 0x00, 0);
 
     // Test case for small positive value (0x01, 0x02 -> 258)
-    msb_lsb_to_sign_magnitude_test!(
-        test_msb_lsb_positive_258,
-        new_mlx90614,
-        0x01,
-        0x02,
-        258
-    );
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_positive_258, new_mlx90614, 0x01, 0x02, 258);
 
     // Test case for maximum positive value (0x7F, 0xFF -> 32767)
-    msb_lsb_to_sign_magnitude_test!(
-        test_msb_lsb_max_positive,
-        new_mlx90614,
-        0x7F,
-        0xFF,
-        32767
-    );
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_max_positive, new_mlx90614, 0x7F, 0xFF, 32767);
 
     // Test case for minimum negative value (0x80, 0x00 -> -32768)
-    msb_lsb_to_sign_magnitude_test!(
-        test_msb_lsb_min_negative,
-        new_mlx90614,
-        0x80,
-        0x00,
-        -0
-    );
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_min_negative, new_mlx90614, 0x80, 0x00, -0);
 
     // Test case for a small negative value (0x81, 0x02 -> -258)
-    msb_lsb_to_sign_magnitude_test!(
-        test_msb_lsb_negative_258,
-        new_mlx90614,
-        0x81,
-        0x02,
-        -258
-    );
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_negative_258, new_mlx90614, 0x81, 0x02, -258);
 
     // Test case for -1 (0xFF, 0xFF -> -1)
-    msb_lsb_to_sign_magnitude_test!(
-        test_msb_lsb_negative_one,
-        new_mlx90614,
-        0xFF,
-        0xFF,
-        -32767
-    );
+    msb_lsb_to_sign_magnitude_test!(test_msb_lsb_negative_one, new_mlx90614, 0xFF, 0xFF, -32767);
 }
 
 mod mlx90614_tests {

--- a/tests/mlx90614.rs
+++ b/tests/mlx90614.rs
@@ -83,7 +83,7 @@ read_u16_test!(
     0x18
 );
 
-read_u16_test!(
+read_i16_test!(
     read_raw_ir1,
     new_mlx90614,
     mlx90614::DEV_ADDR,
@@ -95,7 +95,7 @@ read_u16_test!(
     0x3A26
 );
 
-read_u16_test!(
+read_i16_test!(
     read_raw_ir2,
     new_mlx90614,
     mlx90614::DEV_ADDR,

--- a/tests/mlx90615.rs
+++ b/tests/mlx90615.rs
@@ -61,7 +61,7 @@ read_u16_test!(
     0x18
 );
 
-read_u16_test!(
+read_i16_test!(
     read_raw_ir,
     new_mlx90615,
     mlx90615::DEV_ADDR,


### PR DESCRIPTION
Raw IR channel measurements are i16 types. They represent a voltage which can be positive or negative. If the object is warmer than the sensor it is positive, if the object is colder than the sensor, it is negative. (see datasheet)