### PR TITLE
Introduce Temperature struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [breaking-change] Changed return type of the `raw_ir`, `raw_ir_channel1` and `raw_ir_channel2` methods to `i16` to fix
   a readout conversion error.
+- [breaking-change] Introduced temperature struct for ergonomic temperature conversions.
 
 ## [0.3.0] - 2024-05-23
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ fn main() {
     let mut sensor = Mlx9061x::new_mlx90614(dev, addr, 5).unwrap();
     loop {
         let obj_temp = sensor.object1_temperature().unwrap();
-        println!("Object temperature: {:.2}ºC", obj_temp);
+        println!("Object temperature: {:.2}ºC", obj_temp.celsius());
     }
 }
 ```

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -10,7 +10,7 @@ fn main() {
     let mut sensor = Mlx9061x::new_mlx90614(dev, addr, 5).unwrap();
     loop {
         let obj_temp = sensor.object1_temperature().unwrap();
-        println!("Object temperature: {:.2}ºC", obj_temp);
+        println!("Object temperature: {:.2}ºC", obj_temp.celsius());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,8 @@
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
 //! let addr = SlaveAddr::default();
 //! let mut sensor = Mlx9061x::new_mlx90614(dev, addr, 5).unwrap();
-//! let obj_temp = sensor.object1_temperature().unwrap_or(-1.0);
-//! println!("Object temperature: {:.2}ºC", obj_temp);
+//! let obj_temp = sensor.object1_temperature().unwrap();
+//! println!("Object temperature: {:.2}ºC", obj_temp.celsius());
 //! ```
 //!
 //! ### Read the ambient temperature with an MLX90615
@@ -95,8 +95,8 @@
 //! # let dev = I2cdev::new("/dev/i2c-1").unwrap();
 //! let addr = SlaveAddr::default();
 //! let mut sensor = Mlx9061x::new_mlx90615(dev, addr, 5).unwrap();
-//! let temp = sensor.ambient_temperature().unwrap_or(-1.0);
-//! println!("Ambient temperature: {:.2}ºC", temp);
+//! let temp = sensor.ambient_temperature().unwrap();
+//! println!("Ambient temperature: {:.2}ºC", temp.celsius());
 //! ```
 //!
 //! ### Get the device ID of an MLX90614
@@ -108,7 +108,7 @@
 //! # let dev = I2cdev::new("/dev/i2c-1").unwrap();
 //! # let addr = SlaveAddr::default();
 //! let mut sensor = Mlx9061x::new_mlx90614(dev, addr, 5).unwrap();
-//! let id = sensor.device_id().unwrap_or(0);
+//! let id = sensor.device_id().unwrap();
 //! println!("ID: 0x{:x?}", id);
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ pub use crate::mlx90614::wake_mlx90614;
 mod mlx90615;
 pub use crate::mlx90615::wake_mlx90615;
 mod types;
-pub use crate::types::{ic, Error, SlaveAddr};
+pub use crate::types::{ic, Error, SlaveAddr, Temperature};
 mod common;
 mod register_access;
 

--- a/src/mlx90614.rs
+++ b/src/mlx90614.rs
@@ -3,7 +3,7 @@
 use crate::{
     ic,
     register_access::mlx90614::{self, Register, DEV_ADDR},
-    Error, Mlx9061x, SlaveAddr,
+    Error, Mlx9061x, SlaveAddr, Temperature,
 };
 use core::marker::PhantomData;
 use embedded_hal::{delay::DelayNs, digital::OutputPin, i2c::I2c};
@@ -35,59 +35,24 @@ where
         })
     }
 
-    /// Read the ambient temperature in celsius degrees
-    pub fn ambient_temperature(&mut self) -> Result<f32, Error<E>> {
+    /// Read the ambient temperature
+    pub fn ambient_temperature(&mut self) -> Result<Temperature, Error<E>> {
         let t = self.read_u16(Register::TA)?;
-        let t = f32::from(t) * 0.02 - 273.15;
-        Ok(t)
+        Ok(Temperature(t))
     }
 
-    /// Read the ambient temperature in celsius degrees as u16 value
-    ///
-    /// Note ONLY use to avoid floating-point ops, as this gives less accurate
-    /// temperature readings compared to using `ambient_temperature()`.
-    pub fn ambient_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
-        let t = self.read_u16(Register::TA)?;
-        let t = (t * 2) / 100 - 273;
-        Ok(t)
-    }
-
-    /// Read the object 1 temperature in celsius degrees
-    pub fn object1_temperature(&mut self) -> Result<f32, Error<E>> {
+    /// Read the object 1 temperature
+    pub fn object1_temperature(&mut self) -> Result<Temperature, Error<E>> {
         let t = self.read_u16(Register::TOBJ1)?;
-        let t = f32::from(t) * 0.02 - 273.15;
-        Ok(t)
+        Ok(Temperature(t))
     }
 
-    /// Read the object 1 temperature in celsius degrees as u16 value
-    ///
-    /// Note ONLY use to avoid floating-point ops, as this gives less accurate
-    /// temperature readings compared to using `object1_temperature()`.
-    pub fn object1_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
-        let t = self.read_u16(Register::TOBJ1)?;
-        let t = (t * 2) / 100 - 273;
-        Ok(t)
-    }
-
-    /// Read the object 2 temperature in celsius degrees
+    /// Read the object 2 temperature
     ///
     /// Note that this is only available in dual-zone thermopile device variants.
-    pub fn object2_temperature(&mut self) -> Result<f32, Error<E>> {
+    pub fn object2_temperature(&mut self) -> Result<Temperature, Error<E>> {
         let t = self.read_u16(Register::TOBJ2)?;
-        let t = f32::from(t) * 0.02 - 273.15;
-        Ok(t)
-    }
-
-    /// Read the object 2 temperature in celsius degrees as u16 value
-    ///
-    /// Note that this is only available in dual-zone thermopile device variants.
-    ///
-    /// Note ONLY use to avoid floating-point ops, as this gives less accurate
-    /// temperature readings compared to using `object2_temperature()`.
-    pub fn object2_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
-        let t = self.read_u16(Register::TOBJ2)?;
-        let t = (t * 2) / 100 - 273;
-        Ok(t)
+        Ok(Temperature(t))
     }
 
     /// Read the channel 1 raw IR data

--- a/src/mlx90615.rs
+++ b/src/mlx90615.rs
@@ -1,7 +1,7 @@
 use crate::{
     ic,
     register_access::mlx90615::{self, Register, DEV_ADDR},
-    Error, Mlx9061x, SlaveAddr,
+    Error, Mlx9061x, SlaveAddr, Temperature,
 };
 use core::marker::PhantomData;
 use embedded_hal::{delay::DelayNs, digital::OutputPin, i2c::I2c};
@@ -38,38 +38,16 @@ impl<E, I2C> Mlx9061x<I2C, ic::Mlx90615>
 where
     I2C: I2c<Error = E>,
 {
-    /// Read the ambient temperature in celsius degrees
-    pub fn ambient_temperature(&mut self) -> Result<f32, Error<E>> {
+    /// Read the ambient temperature
+    pub fn ambient_temperature(&mut self) -> Result<Temperature, Error<E>> {
         let t = self.read_u16(Register::TA)?;
-        let t = f32::from(t) * 0.02 - 273.15;
-        Ok(t)
+        Ok(Temperature(t))
     }
 
-    /// Read the ambient temperature in celsius degrees as u16 value
-    ///
-    /// Note ONLY use to avoid floating-point ops, as this gives less accurate
-    /// temperature readings compared to using `ambient_temperature()`.
-    pub fn ambient_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
-        let t = self.read_u16(Register::TA)?;
-        let t = (t * 2) / 100 - 273;
-        Ok(t)
-    }
-
-    /// Read the object temperature in celsius degrees
-    pub fn object_temperature(&mut self) -> Result<f32, Error<E>> {
+    /// Read the object temperature
+    pub fn object_temperature(&mut self) -> Result<Temperature, Error<E>> {
         let t = self.read_u16(Register::TOBJ)?;
-        let t = f32::from(t) * 0.02 - 273.15;
-        Ok(t)
-    }
-
-    /// Read the object temperature in celsius degrees
-    ///
-    /// Note ONLY use to avoid floating-point ops, as this gives less accurate
-    /// temperature readings compared to using `object_temperature()`.
-    pub fn object_temperature_as_int(&mut self) -> Result<u16, Error<E>> {
-        let t = self.read_u16(Register::TOBJ)?;
-        let t = (t * 2) / 100 - 273;
-        Ok(t)
+        Ok(Temperature(t))
     }
 
     /// Read the raw IR data

--- a/src/types.rs
+++ b/src/types.rs
@@ -71,6 +71,6 @@ impl Temperature {
 
     /// Temperature in millifahrenheit
     pub fn millifahrenheit(&self) -> i32 {
-        self.millikelvin() as i32 * 900 - 459670
+        self.millikelvin() as i32 * 9 / 5 - 459670
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -76,3 +76,32 @@ impl Temperature {
         self.millikelvin() as i32 * 9 / 5 - 459670
     }
 }
+
+#[cfg(test)]
+mod temperature_tests {
+    use super::Temperature;
+
+    #[test]
+    fn conversions() {
+        let temp = Temperature(13658);
+        assert_eq!(temp.raw(), 13658);
+        assert!((temp.kelvin() - 273.16).abs() < 0.001);
+        assert!((temp.celsius() - 0.01).abs() < 0.001);
+        assert!((temp.fahrenheit() - 32.018).abs() < 0.001);
+        assert_eq!(temp.millikelvin(), 273160);
+        assert_eq!(temp.millicelsius(), 10);
+        assert_eq!(temp.millifahrenheit(), 32018);
+    }
+
+    #[test]
+    fn zero() {
+        let temp = Temperature(0);
+        assert_eq!(temp.raw(), 0);
+        assert!((temp.kelvin() - 0.0).abs() < 0.001);
+        assert!((temp.celsius() - (-273.15)).abs() < 0.001);
+        assert!((temp.fahrenheit() - (-459.67)).abs() < 0.001);
+        assert_eq!(temp.millikelvin(), 0);
+        assert_eq!(temp.millicelsius(), -273150);
+        assert_eq!(temp.millifahrenheit(), -459670);
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,3 +34,43 @@ impl Default for SlaveAddr {
         SlaveAddr::Default
     }
 }
+
+/// Temperature value
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Temperature(
+    /// Raw temperature value
+    pub u16,
+);
+
+impl Temperature {
+    /// Temperature in kelvin
+    pub fn kelvin(&self) -> f32 {
+        self.0 as f32 * 0.02
+    }
+
+    /// Temperature in celsius
+    pub fn celsius(&self) -> f32 {
+        self.kelvin() - 273.15
+    }
+
+    /// Temperature in fahrenheit
+    pub fn fahrenheit(&self) -> f32 {
+        self.kelvin() * 9.0 / 5.0 - 459.67
+    }
+
+    /// Temperature in millikelvin
+    pub fn millikelvin(&self) -> u32 {
+        self.0 as u32 * 20
+    }
+
+    /// Temperature in millicelsius
+    pub fn millicelsius(&self) -> i32 {
+        self.millikelvin() as i32 - 273150
+    }
+
+    /// Temperature in millifahrenheit
+    pub fn millifahrenheit(&self) -> i32 {
+        self.millikelvin() as i32 * 900 - 459670
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,12 +38,14 @@ impl Default for SlaveAddr {
 /// Temperature value
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Temperature(
-    /// Raw temperature value
-    pub u16,
-);
+pub struct Temperature(pub(crate) u16);
 
 impl Temperature {
+    /// Raw temperature value
+    pub fn raw(&self) -> u16 {
+        self.0
+    }
+
     /// Temperature in kelvin
     pub fn kelvin(&self) -> f32 {
         self.0 as f32 * 0.02

--- a/tests/base/mod.rs
+++ b/tests/base/mod.rs
@@ -93,7 +93,7 @@ macro_rules! read_f32_test_base {
 }
 
 #[macro_export]
-macro_rules! read_u16_test {
+macro_rules! read_temp_test_base {
     ($name:ident, $create:ident, $address:expr, $method:ident, $reg:expr, $data0:expr, $data1:expr, $data2:expr, $expected:expr) => {
         #[test]
         fn $name() {
@@ -103,7 +103,7 @@ macro_rules! read_u16_test {
                 vec![$data0, $data1, $data2],
             )]);
             let t = sensor.$method().unwrap();
-            assert_eq!(t, $expected);
+            assert_near!(t.celsius(), $expected, 0.1);
             destroy(sensor);
         }
     };

--- a/tests/mlx90614.rs
+++ b/tests/mlx90614.rs
@@ -22,12 +22,27 @@ macro_rules! read_f32_test {
         );
     };
 }
-read_f32_test!(read_ta1, ambient_temperature, Reg::TA, 225, 57, 233, 23.19);
-read_f32_test!(read_ta2, ambient_temperature, Reg::TA, 97, 58, 86, 25.75);
-read_f32_test!(read_ta3, ambient_temperature, Reg::TA, 107, 58, 212, 25.95);
-read_f32_test!(read_ta4, ambient_temperature, Reg::TA, 38, 58, 102, 24.57);
+macro_rules! read_temp_test {
+    ($name:ident, $method:ident, $reg:expr, $data0:expr, $data1:expr, $data2:expr, $expected:expr) => {
+        read_temp_test_base!(
+            $name,
+            new_mlx90614,
+            mlx90614::DEV_ADDR,
+            $method,
+            $reg,
+            $data0,
+            $data1,
+            $data2,
+            $expected
+        );
+    };
+}
+read_temp_test!(read_ta1, ambient_temperature, Reg::TA, 225, 57, 233, 23.19);
+read_temp_test!(read_ta2, ambient_temperature, Reg::TA, 97, 58, 86, 25.75);
+read_temp_test!(read_ta3, ambient_temperature, Reg::TA, 107, 58, 212, 25.95);
+read_temp_test!(read_ta4, ambient_temperature, Reg::TA, 38, 58, 102, 24.57);
 
-read_f32_test!(
+read_temp_test!(
     read_object1_temp,
     object1_temperature,
     Reg::TOBJ1,
@@ -37,7 +52,7 @@ read_f32_test!(
     24.57
 );
 
-read_f32_test!(
+read_temp_test!(
     read_object2_temp,
     object2_temperature,
     Reg::TOBJ2,
@@ -45,42 +60,6 @@ read_f32_test!(
     58,
     162,
     24.57
-);
-
-read_u16_test!(
-    read_ta_as_int,
-    new_mlx90614,
-    mlx90614::DEV_ADDR,
-    ambient_temperature_as_int,
-    Reg::TA,
-    0x0,
-    0x3A,
-    0xB6,
-    0x17
-);
-
-read_u16_test!(
-    read_object1_temp_as_int,
-    new_mlx90614,
-    mlx90614::DEV_ADDR,
-    object1_temperature_as_int,
-    Reg::TOBJ1,
-    0x26,
-    0x3A,
-    0x70,
-    0x18
-);
-
-read_u16_test!(
-    read_object2_temp_as_int,
-    new_mlx90614,
-    mlx90614::DEV_ADDR,
-    object2_temperature_as_int,
-    Reg::TOBJ2,
-    0x26,
-    0x3A,
-    0xA2,
-    0x18
 );
 
 read_i16_test!(

--- a/tests/mlx90615.rs
+++ b/tests/mlx90615.rs
@@ -22,12 +22,27 @@ macro_rules! read_f32_test {
         );
     };
 }
-read_f32_test!(read_ta1, ambient_temperature, Reg::TA, 225, 57, 53, 23.19);
-read_f32_test!(read_ta2, ambient_temperature, Reg::TA, 97, 58, 138, 25.75);
-read_f32_test!(read_ta3, ambient_temperature, Reg::TA, 107, 58, 8, 25.95);
-read_f32_test!(read_ta4, ambient_temperature, Reg::TA, 38, 58, 186, 24.57);
+macro_rules! read_temp_test {
+    ($name:ident, $method:ident, $reg:expr, $data0:expr, $data1:expr, $data2:expr, $expected:expr) => {
+        read_temp_test_base!(
+            $name,
+            new_mlx90615,
+            mlx90615::DEV_ADDR,
+            $method,
+            $reg,
+            $data0,
+            $data1,
+            $data2,
+            $expected
+        );
+    };
+}
+read_temp_test!(read_ta1, ambient_temperature, Reg::TA, 225, 57, 53, 23.19);
+read_temp_test!(read_ta2, ambient_temperature, Reg::TA, 97, 58, 138, 25.75);
+read_temp_test!(read_ta3, ambient_temperature, Reg::TA, 107, 58, 8, 25.95);
+read_temp_test!(read_ta4, ambient_temperature, Reg::TA, 38, 58, 186, 24.57);
 
-read_f32_test!(
+read_temp_test!(
     read_object_temp,
     object_temperature,
     Reg::TOBJ,
@@ -35,30 +50,6 @@ read_f32_test!(
     58,
     172,
     24.57
-);
-
-read_u16_test!(
-    read_object_temp_as_int,
-    new_mlx90615,
-    mlx90615::DEV_ADDR,
-    object_temperature_as_int,
-    Reg::TOBJ,
-    0x26,
-    0x3A,
-    0xAC,
-    0x18
-);
-
-read_u16_test!(
-    read_ta_as_int,
-    new_mlx90615,
-    mlx90615::DEV_ADDR,
-    ambient_temperature_as_int,
-    Reg::TA,
-    0x26,
-    0x3A,
-    0xBA,
-    0x18
 );
 
 read_i16_test!(


### PR DESCRIPTION
Introduces Temperature struct for ergonomic temperature conversions. Users that want to avoid f32 can use milli equivalent conversions.